### PR TITLE
FEAT: support the use of http to get the configuration, which has a higher priority than redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.22.0] - 2023-05-29
+### Features
+
+- Support http method to get manager configurations
+
 ## [v0.21.1] - 2023-05-18
 
 ### Bug Fixes

--- a/crates/piam-core/Cargo.toml
+++ b/crates/piam-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piam-core"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 description = "Patsnap IAM core"
 license = "Apache-2.0 OR MIT"

--- a/crates/piam-core/src/manager_api_constant.rs
+++ b/crates/piam-core/src/manager_api_constant.rs
@@ -15,6 +15,11 @@ pub const USER_GROUP_RELATIONSHIPS: &str = "user_group_relationships";
 pub const POLICY_RELATIONSHIPS: &str = "policy_relationships";
 
 pub const EXTENDED_CONFIG: &str = "extended_config";
+
+pub const S3: &str = "s3";
+
+pub const OBJECT_STORAGE: &str = "ObjectStorage";
+
 /// for manager use only
 pub const CONFIG_TYPE: &str = "config_type";
 

--- a/crates/piam-manager/Cargo.toml
+++ b/crates/piam-manager/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4.17"
 redis = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.4.0"
+serde_json = "1.0.96"
 
 [dev-dependencies]
 piam-object-storage = { path = "../piam-object-storage" }

--- a/crates/piam-manager/Cargo.toml
+++ b/crates/piam-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piam-manager"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/piam-manager/Cargo.toml
+++ b/crates/piam-manager/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1", features = ["full"] }
 log = "0.4.17"
 redis = "0.22"
 serde = { version = "1.0", features = ["derive"] }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 piam-object-storage = { path = "../piam-object-storage" }

--- a/crates/piam-manager/src/config.rs
+++ b/crates/piam-manager/src/config.rs
@@ -13,23 +13,29 @@ pub fn port() -> u16 {
     80
 }
 
-pub static PORTAL_ADDRESS: GlobalString =
-    GlobalString::new(|| env_var_with_default("PORTAL_ADDRESS", "http://localhost:80"));
+pub static PIAM_HTTP_RESOURCE_ADDRESS: GlobalString =
+    GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_ADDRESS", "http://localhost:80"));
 
-pub static PORTAL_API_VERSION: GlobalString =
-    GlobalString::new(|| env_var_with_default("PORTAL_API_VERSION", "v2023-03"));
+pub static PIAM_HTTP_RESOURCE_API_VERSION: GlobalString =
+    GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_API_VERSION", "v2023-03"));
+pub static PIAM_HTTP_RESOURCE_URL_PREFIX: GlobalString =
+    GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_URL_PREFIX",
+                                              format!("{}/{}/{}",
+                                                      PIAM_HTTP_RESOURCE_ADDRESS.load(),
+                                                      PIAM_HTTP_RESOURCE_API_VERSION.load(),
+                                                      "piam").as_str()));
 
 lazy_static! {
-    pub static ref PORTAL_API_PATH: HashMap<&'static str, &'static str> = {
+    pub static ref PIAM_HTTP_PATH_REDIS_KEY_MAPPER: HashMap<&'static str, &'static str> = {
         let mut map = HashMap::new();
         map.insert(ACCOUNTS, "accounts");
         map.insert(USERS, "users");
         map.insert(GROUPS, "groups");
-        map.insert(POLICIES, "policies");
-        map.insert(CONDITION, "conditions");
+        map.insert(Box::leak(format!("{}:{}", POLICIES, "ObjectStorage").into_boxed_str()), "policies/kind/ObjectStorage");
+        map.insert(Box::leak(format!("{}:{}", POLICIES, CONDITION).into_boxed_str()), "policies/kind/Condition");
         map.insert(USER_GROUP_RELATIONSHIPS, "relationships/user_group");
         map.insert(POLICY_RELATIONSHIPS, "relationships/policy");
-        map.insert(EXTENDED_CONFIG, "extended_configurations");
+        map.insert(EXTENDED_CONFIG, "extended_config");
         map
     };
 }

--- a/crates/piam-manager/src/config.rs
+++ b/crates/piam-manager/src/config.rs
@@ -1,4 +1,7 @@
 use busylib::config::{dev_mode, env_var_with_default, GlobalString};
+use std::collections::HashMap;
+use lazy_static::lazy_static;
+use piam_core::manager_api_constant::*;
 
 pub static REDIS_ADDRESS: GlobalString =
     GlobalString::new(|| env_var_with_default("REDIS_ADDRESS", "redis://localhost/1"));
@@ -8,4 +11,25 @@ pub fn port() -> u16 {
         return 8080;
     }
     80
+}
+
+pub static PORTAL_ADDRESS: GlobalString =
+    GlobalString::new(|| env_var_with_default("PORTAL_ADDRESS", "http://localhost:80"));
+
+pub static PORTAL_API_VERSION: GlobalString =
+    GlobalString::new(|| env_var_with_default("PORTAL_API_VERSION", "v2023-03"));
+
+lazy_static! {
+    pub static ref PORTAL_API_PATH: HashMap<&'static str, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert(ACCOUNTS, "accounts");
+        map.insert(USERS, "users");
+        map.insert(GROUPS, "groups");
+        map.insert(POLICIES, "policies");
+        map.insert(CONDITION, "conditions");
+        map.insert(USER_GROUP_RELATIONSHIPS, "relationships/user_group");
+        map.insert(POLICY_RELATIONSHIPS, "relationships/policy");
+        map.insert(EXTENDED_CONFIG, "extended_configurations");
+        map
+    };
 }

--- a/crates/piam-manager/src/config.rs
+++ b/crates/piam-manager/src/config.rs
@@ -14,7 +14,7 @@ pub fn port() -> u16 {
 }
 
 pub static PIAM_HTTP_RESOURCE_ADDRESS: GlobalString =
-    GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_ADDRESS", "http://localhost:80"));
+    GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_ADDRESS", "http://localhost:8080"));
 
 pub static PIAM_HTTP_RESOURCE_API_VERSION: GlobalString =
     GlobalString::new(|| env_var_with_default("PIAM_HTTP_RESOURCE_API_VERSION", "v2023-03"));
@@ -28,14 +28,23 @@ pub static PIAM_HTTP_RESOURCE_URL_PREFIX: GlobalString =
 lazy_static! {
     pub static ref PIAM_HTTP_PATH_REDIS_KEY_MAPPER: HashMap<&'static str, &'static str> = {
         let mut map = HashMap::new();
-        map.insert(ACCOUNTS, "accounts");
         map.insert(USERS, "users");
         map.insert(GROUPS, "groups");
-        map.insert(Box::leak(format!("{}:{}", POLICIES, "ObjectStorage").into_boxed_str()), "policies/kind/ObjectStorage");
-        map.insert(Box::leak(format!("{}:{}", POLICIES, CONDITION).into_boxed_str()), "policies/kind/Condition");
-        map.insert(USER_GROUP_RELATIONSHIPS, "relationships/user_group");
+        map.insert(ACCOUNTS, "accounts");
         map.insert(POLICY_RELATIONSHIPS, "relationships/policy");
-        map.insert(EXTENDED_CONFIG, "extended_config");
+        map.insert(USER_GROUP_RELATIONSHIPS, "relationships/user_group");
+        map.insert(
+            Box::leak(format!("{}:{}", POLICIES, CONDITION).into_boxed_str()),
+            "policies/kind/Condition"
+        );
+        map.insert(
+            Box::leak(format!("{}:{}", EXTENDED_CONFIG, S3).into_boxed_str()),
+            "extended_configurations"
+        );
+        map.insert(
+            Box::leak(format!("{}:{}", POLICIES, OBJECT_STORAGE).into_boxed_str()),
+            "policies/kind/ObjectStorage"
+        );
         map
     };
 }

--- a/crates/piam-manager/src/error.rs
+++ b/crates/piam-manager/src/error.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use busylib::http::ReqwestError;
 
 pub type ManagerResult<T> = Result<T, ManagerError>;
 
@@ -14,5 +15,11 @@ impl fmt::Display for ManagerError {
             ManagerError::BadRequest(msg) => write!(f, "BadRequest: {msg}"),
             ManagerError::Internal(msg) => write!(f, "Internal: {msg}"),
         }
+    }
+}
+
+impl From<ReqwestError> for ManagerError {
+    fn from(err: ReqwestError) -> Self {
+        Self::Internal(format!("reqwest error: {err}"))
     }
 }

--- a/crates/piam-manager/src/persist.rs
+++ b/crates/piam-manager/src/persist.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub async fn get_resource_string(key: &str) -> ManagerResult<String> {
-    let string = ManagerResourceClient::new().get_resource_string(key).await.map_err(|e| {
+    let string = ManagerResourceClient::default().get_resource_string(key).await.map_err(|e| {
         warn!("failed to get resource configurations, error: {}", e);
         e
     })?;
@@ -25,14 +25,16 @@ pub struct ManagerResourceClient {
     redis_client: Option<Client>,
 }
 
-impl ManagerResourceClient {
-    pub fn new() -> Self {
+impl Default for ManagerResourceClient {
+    fn default() -> Self {
         Self {
             http_client: Some(default_reqwest_client()),
             redis_client: Client::open(REDIS_ADDRESS.load().as_str()).ok(),
         }
     }
+}
 
+impl ManagerResourceClient {
     pub async fn get_resource_string(&self, key: &str) -> Result<String, ManagerError> {
         match self.get_resource_from_http(key).await {
             Ok(result) => Ok(result),

--- a/crates/piam-manager/src/persist.rs
+++ b/crates/piam-manager/src/persist.rs
@@ -1,20 +1,90 @@
 use piam_core::manager_api_constant::VERSION;
-use redis::Commands;
+use redis::{Client, Commands};
+use busylib::http::{
+    default_reqwest_client,
+    ReqwestClient,
+};
+use log::{info, warn};
+use std::option::Option;
 
 use crate::{
-    config::REDIS_ADDRESS,
+    config::{REDIS_ADDRESS, PORTAL_ADDRESS, PORTAL_API_VERSION, PORTAL_API_PATH},
     error::{ManagerError, ManagerResult},
 };
 
 pub async fn get_resource_string(key: &str) -> ManagerResult<String> {
-    let client = redis::Client::open(REDIS_ADDRESS.load().as_str())
-        .map_err(|e| ManagerError::Internal(format!("failed to create redis client: {}", e)))?;
-    let mut con = client
-        .get_connection()
-        .map_err(|e| ManagerError::Internal(format!("failed to get redis connection: {}", e)))?;
-    let key = format!("piam:{}:{}", VERSION, key);
-    let string = con.get(&key).map_err(|e| {
-        ManagerError::Internal(format!("failed to get redis key: {} error: {}", key, e))
+    let string = ManagerResourceClient::new().get_resource_string(key).await.map_err(|e| {
+        warn!("failed to get resource configurations, error: {}", e);
+        e
     })?;
     Ok(string)
+}
+
+pub struct ManagerResourceClient {
+    http_client: Option<ReqwestClient>,
+    redis_client: Option<Client>,
+}
+
+impl ManagerResourceClient {
+    pub fn new() -> Self {
+        Self {
+            http_client: Some(default_reqwest_client()),
+            redis_client: Client::open(REDIS_ADDRESS.load().as_str()).ok(),
+        }
+    }
+
+    pub async fn get_resource_string(&self, key: &str) -> Result<String, ManagerError> {
+        match self.get_resource_from_portal(key).await {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                warn!("failed to get resource from portal: {}", err);
+                info!("try to get resource from redis");
+                match self.get_resource_from_redis(key).await {
+                    Ok(result) => Ok(result),
+                    Err(err) => {
+                        warn!("failed to get resource from redis: {}", err);
+                        Err(err)
+                    }
+                }
+            }
+        }
+    }
+
+    async fn get_resource_from_redis(&self, key: &str) -> Result<String, ManagerError> {
+        let client = self.redis_client.as_ref().ok_or_else(|| {
+            ManagerError::Internal("redis client is not initialized".to_owned())
+        })?;
+
+        let key = format!("piam:{}:{}", VERSION, key);
+        let mut con = client
+            .get_connection()
+            .map_err(|e| ManagerError::Internal(format!("failed to get redis connection: {}", e)))?;
+        let string: Option<String> = con.get(&key).map_err(|e| {
+            ManagerError::Internal(format!("failed to get redis key: {} error: {}", key, e))
+        })?;
+        string.ok_or_else(|| ManagerError::BadRequest(key.to_owned()))
+    }
+
+    async fn get_resource_from_portal(&self, key: &str) -> Result<String, ManagerError> {
+        let path = PORTAL_API_PATH.get(key).ok_or_else(|| {
+            ManagerError::BadRequest(format!("failed to get resource from portal, key: {}", key))
+        })?;
+
+        let url = format!("{}/{}/piam/{}", PORTAL_ADDRESS.load(), PORTAL_API_VERSION.load(), path);
+        let client = self.http_client.as_ref().ok_or_else(|| {
+            ManagerError::Internal("http client is not initialized".to_owned())
+        })?;
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ManagerError::Internal(format!("failed to get portal resource: {}", e)))?
+            .error_for_status()
+            .map_err(|e| ManagerError::Internal(format!("failed to get portal resource: {}", e)))?
+            .text()
+            .await
+            .map_err(|e| ManagerError::Internal(format!("failed to get portal resource: {}", e)))?;
+
+        Ok(response)
+    }
 }

--- a/crates/piam-object-storage/Cargo.toml
+++ b/crates/piam-object-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piam-object-storage"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/piam-proxy/Cargo.toml
+++ b/crates/piam-proxy/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.17"
 axum = { version = "0.6.1", features = ["tokio"]}
 async-trait = "0.1"
 itertools = { version = "0.10.5", optional = true }
+serde_json = "1.0.96"
 
 [dependencies.serde-xml-rs]
 version = "0.6.0"

--- a/crates/piam-proxy/Cargo.toml
+++ b/crates/piam-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piam-proxy"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/piam-proxy/src/manager_api.rs
+++ b/crates/piam-proxy/src/manager_api.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use busylib::http::ReqwestClient;
-use log::{info, warn};
+use log::warn;
 use piam_core::{
     account::aws::AwsAccount,
     crypto::decrypt,
@@ -15,7 +15,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     config::{CoreConfig, PIAM_MANAGER_ADDRESS, POLICY_MODEL},
-    error::{deserialize, ProxyError, ProxyResult},
+    error::{ProxyError, ProxyResult},
 };
 
 #[derive(Debug)]


### PR DESCRIPTION
Support the use of http to get the configuration, which has a higher priority than redis.